### PR TITLE
Feat: Addition of chat history and login page - Feature/chat history

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -9,3 +9,7 @@ database:
   username: "root"
   password: "Hello@123952"
   name: "hrms"
+
+auth:
+  username: chirag
+  password: hello123

--- a/src/app.py
+++ b/src/app.py
@@ -1,63 +1,124 @@
 import streamlit as st
-from utils import connect_database, get_llm_response, convert_result_to_csv, config
-import os
+from utils import config, connect_database, get_llm_response, convert_result_to_csv
+
 
 class MySQLChatApp:
     def __init__(self):
-        st.set_page_config(page_title="Chat with MySQL DB", layout="centered")
+        self.init_session()
+        self.setup_ui()
+
+    def init_session(self):
+        # Initialize session state if not already initialized
+        if "chat" not in st.session_state:
+            st.session_state.chat = []
+        if "chat_histories" not in st.session_state:
+            st.session_state.chat_histories = {}
+        if "active_chat" not in st.session_state:
+            st.session_state.active_chat = None
         if "logged_in" not in st.session_state:
             st.session_state.logged_in = False
-        if not st.session_state.logged_in:
-            self.login()
-        else:
-            self.setup_ui()
-
-    def login(self):
-        st.title("🔐 Login")
-        username = st.text_input("Username")
-        password = st.text_input("Password", type="password")
-        if st.button("Login"):
-            if (
-                username == config["auth"]["username"]
-                and password == config["auth"]["password"]
-            ):
-                st.session_state.logged_in = True
-                st.rerun()
-            else:
-                st.error("❌ Invalid credentials")
 
     def setup_ui(self):
-        st.sidebar.title("🗂️ Chat History")
-        self.show_history_sidebar()
+        # Show login page if not logged in
+        if not st.session_state.logged_in:
+            self.show_login_page()
+        else:
+            # Main page with database and chat functionality
+            self.setup_main_page()
 
-        st.title("🧠 Chat with MySQL")
-        with st.expander("📡 Connect to Database", expanded=True):
-            host = st.text_input("Host", value="localhost")
-            user = st.text_input("User", value="root")
-            password = st.text_input("Password", type="password")
-            database = st.text_input("Database Name")
-            port = st.text_input("Port", value="3306")
+    def show_login_page(self):
+        st.title("Login to MySQL Chat App")
 
-            if st.button("Connect"):
-                connect_database(host, user, password, database, port)
+        # Login form
+        username = st.text_input("Username", key="login_username")
+        password = st.text_input("Password", type="password", key="login_password")
+        login_button = st.button("Login")
 
-        if "db" in st.session_state:
-            st.markdown("### 💬 Ask your database anything")
-            question = st.text_area("Enter your question:", height=100)
-            if st.button("Send"):
-                if question.strip():
-                    response, result = get_llm_response(question)
-                    st.markdown(response, unsafe_allow_html=True)
-                    if result:
-                        csv = convert_result_to_csv(result)
-                        if csv:
-                            st.download_button("⬇️ Download CSV", data=csv, file_name="query_result.csv", mime="text/csv")
+        # Check if credentials are correct
+        if login_button:
+            if username == config["auth"]["username"] and password == config["auth"]["password"]:
+                st.session_state.logged_in = True
+                st.success("Login successful! Redirecting to the app...")
+                st.rerun()  # Reload the page after successful login
+            else:
+                st.error("Invalid username or password!")
 
-    def show_history_sidebar(self):
-        if "conversation_history" in st.session_state:
-            for i, msg in enumerate(reversed(st.session_state.conversation_history)):
-                role = "🧑" if msg["role"] == "user" else "🤖"
-                st.sidebar.markdown(f"{role} {msg['content'][:100]}")
+    def setup_main_page(self):
+        st.set_page_config(page_title="Chat with MySQL DB", layout="centered")
+        st.title("Chat with Your MySQL Database")
+        self.setup_sidebar()
+        self.handle_chat()
+
+    def setup_sidebar(self):
+        with st.sidebar:
+            # Database connection section with an expander
+            with st.expander("📡 Connect to Database", expanded=True):
+                st.title('🔗 Connect to Database')
+                st.text_input(label="Host", key="host", value=config["database"]["host"])
+                st.text_input(label="Port", key="port", value=str(config["database"]["port"]))
+                st.text_input(label="Username", key="username", value=config["database"]["username"])
+                st.text_input(label="Password", key="password", type="password", value=config["database"]["password"])
+                st.text_input(label="Database", key="database", value=config["database"]["name"])
+                if st.button("Connect"):
+                    connect_database(
+                        host=st.session_state.host,
+                        user=st.session_state.username,
+                        password=st.session_state.password,
+                        database=st.session_state.database,
+                        port=st.session_state.port,
+                    )
+
+            st.markdown("---")
+
+            # Chat History section
+            st.title("🗂️ Chat History")
+
+            # New Chat button to start a fresh conversation
+            if st.button("➕ New Chat"):
+                new_chat_name = f"Chat {len(st.session_state.chat_histories) + 1}"
+                st.session_state.chat_histories[new_chat_name] = []
+                st.session_state.active_chat = new_chat_name
+                st.session_state.chat = []
+                st.session_state.conversation_history = []
+
+            # Display existing chat histories as expandable sections
+            for chat_title in list(st.session_state.chat_histories.keys()):
+                with st.expander(chat_title, expanded=(chat_title == st.session_state.active_chat)):
+                    if st.button(f"🟢 Open {chat_title}", key=f"open_{chat_title}"):
+                        st.session_state.active_chat = chat_title
+                        st.session_state.chat = st.session_state.chat_histories[chat_title]
+                        st.session_state.conversation_history = [
+                            msg for msg in st.session_state.chat if msg["role"] in ["user", "assistant"]
+                        ]
+
+    def handle_chat(self):
+        question = st.chat_input('💬 Ask anything about your database')
+        if question:
+            if "db" not in st.session_state or not st.session_state.db:
+                st.error('Please connect to the database first.')
+                return
+
+            st.session_state.conversation_history.append({"role": "user", "content": question})
+            response, raw_result = get_llm_response(question)
+            st.session_state.conversation_history.append({"role": "assistant", "content": response})
+            st.session_state.chat.append({"role": "user", "content": question})
+            st.session_state.chat.append({"role": "assistant", "content": response})
+            st.session_state.last_result = raw_result  # Save only the data table
+
+        for i, chat in enumerate(st.session_state.chat):
+            st.chat_message(chat['role']).markdown(chat['content'])
+
+            # If it's the last assistant message and has a result, show download
+            is_last_message = i == len(st.session_state.chat) - 1
+            if chat['role'] == 'assistant' and is_last_message:
+                if "last_result" in st.session_state and st.session_state.last_result:
+                    csv = convert_result_to_csv(st.session_state.last_result)
+                    st.download_button(
+                        label="⬇️ Download table as CSV",
+                        data=csv,
+                        file_name="query_results.csv",
+                        mime="text/csv"
+                    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### What’s Changed

- Added Login Page gated by credentials from config.yaml.
- Session-based Auth with reroute on successful login.
- Sidebar Revamp:
   1. "Connect to Database" as expandable section.
   2. "Chat History" with new chat creation and session switching.
- Cleaner State Handling for active chat and conversation history.

### How to Test

- Launch app: streamlit run app.py
- Enter login credentials (from config).
- Test DB connection and chat interactions via sidebar.
- Validate switching chats, starting new ones, and normal chat flow.


![Screenshot from 2025-04-24 14-50-32](https://github.com/user-attachments/assets/27c501b8-b07b-4d3f-b5f7-90e0c0cc3052)
![Screenshot from 2025-04-24 14-52-05](https://github.com/user-attachments/assets/44e7860c-5401-401d-9294-bac29596aef2)
![Screenshot from 2025-04-24 14-53-39](https://github.com/user-attachments/assets/ad8300ac-30b0-42c5-a6f6-6d7991d7d3c7)


